### PR TITLE
Global headers

### DIFF
--- a/Widgets/frequesttreewidgetprojectitem.h
+++ b/Widgets/frequesttreewidgetprojectitem.h
@@ -39,7 +39,7 @@ public:
 	// can't use optional because it is an abstract base class, using unique_ptr as nullptr as alternative
     std::shared_ptr<FRequestAuthentication> authData = nullptr;
     UtilFRequest::IdentCharacter saveIdentCharacter = UtilFRequest::IdentCharacter::SPACE; // space by default
-    QVector<UtilFRequest::HttpHeader> headers;
+    QVector<UtilFRequest::HttpHeader> globalHeaders;
 private:
     QString uuid;
     QHash<QString, FRequestTreeWidgetRequestItem *> mapOfChilds_UuidToRequest;

--- a/Widgets/frequesttreewidgetprojectitem.h
+++ b/Widgets/frequesttreewidgetprojectitem.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define FREQUESTTREEWIDGETPROJECTITEM_H
 
 #include "frequesttreewidgetrequestitem.h"
+#include "utilfrequest.h"
 
 class FRequestTreeWidgetProjectItem : public FRequestTreeWidgetItem
 {
@@ -38,6 +39,7 @@ public:
 	// can't use optional because it is an abstract base class, using unique_ptr as nullptr as alternative
     std::shared_ptr<FRequestAuthentication> authData = nullptr;
     UtilFRequest::IdentCharacter saveIdentCharacter = UtilFRequest::IdentCharacter::SPACE; // space by default
+    QVector<UtilFRequest::HttpHeader> headers;
 private:
     QString uuid;
     QHash<QString, FRequestTreeWidgetRequestItem *> mapOfChilds_UuidToRequest;

--- a/XmlParsers/configfilefrequest.cpp
+++ b/XmlParsers/configfilefrequest.cpp
@@ -46,6 +46,7 @@ void ConfigFileFRequest::createNewConfig(){
     generalNode.append_attribute("lastProjectPath");
     generalNode.append_attribute("lastResponseFilePath");
     generalNode.append_attribute("showRequestTypesIcons");
+    generalNode.append_attribute("hideProjectSavedDialog");
 
     pugi::xml_node recentProjectsNode = rootNode.append_child("RecentProjects");
 
@@ -113,6 +114,7 @@ void ConfigFileFRequest::saveSettings(ConfigFileFRequest::Settings &newSettings)
         generalNode.attribute("lastProjectPath").set_value(QSTR_TO_CSTR(newSettings.lastProjectPath));
         generalNode.attribute("lastResponseFilePath").set_value(QSTR_TO_CSTR(newSettings.lastResponseFilePath));
         generalNode.attribute("showRequestTypesIcons").set_value(newSettings.showRequestTypesIcons);
+        generalNode.attribute("hideProjectSavedDialog").set_value(newSettings.hideProjectSavedDialog);
 
         pugi::xml_node recentProjectsNode = doc.select_single_node("/FRequestConfig/RecentProjects").node();
 
@@ -266,6 +268,7 @@ void ConfigFileFRequest::readSettingsFromFile(){
         this->currentSettings.lastProjectPath = generalNode.attribute("lastProjectPath").as_string();
         this->currentSettings.lastResponseFilePath = generalNode.attribute("lastResponseFilePath").as_string();
         this->currentSettings.showRequestTypesIcons = generalNode.attribute("showRequestTypesIcons").as_bool();
+        this->currentSettings.hideProjectSavedDialog = generalNode.attribute("hideProjectSavedDialog").as_bool();
 
         pugi::xml_node recentProjectsNode = doc.select_single_node("/FRequestConfig/RecentProjects").node();
 
@@ -604,6 +607,20 @@ void ConfigFileFRequest::upgradeConfigFileIfNecessary(){
 		
 		configVersion = versionAfterUpgrade;
 	}
+
+    if (configVersion =="1.1b") {
+        const QString versionAfterUpgrade = "1.2";
+
+        doc.select_single_node("/FRequestConfig").node().attribute("frequestVersion").set_value(QSTR_TO_CSTR(versionAfterUpgrade));
+
+        pugi::xml_node generalNode = doc.select_single_node("/FRequestConfig/General").node();
+
+        generalNode.append_attribute("hideProjectSavedDialog").set_value(false);
+
+        fSaveFileAfterUpgrade(this->fileFullPath, versionAfterUpgrade);
+
+        configVersion = versionAfterUpgrade;
+    }
 	
     if(configVersion != GlobalVars::LastCompatibleVersionConfig){
         throw std::runtime_error("Can't load the config file, it is from an incompatible version. Probably newer?");

--- a/XmlParsers/configfilefrequest.h
+++ b/XmlParsers/configfilefrequest.h
@@ -98,6 +98,7 @@ public:
         ProxySettings proxySettings;
 		// the hash map below contains the authentication data of the projects that specified it to be saved on config file instead of in project file
 		QHash<QString, ConfigurationProjectAuthentication> mapOfConfigAuths_UuidToConfigAuth;
+        bool hideProjectSavedDialog = false;
     };
 
 public:

--- a/XmlParsers/projectfilefrequest.cpp
+++ b/XmlParsers/projectfilefrequest.cpp
@@ -160,12 +160,12 @@ ProjectFileFRequest::ProjectData ProjectFileFRequest::readProjectDataFromFile(co
         QVector<UtilFRequest::HttpHeader> requestHeaders;
 
         for(const pugi::xml_node &currentHeaderNode : currNode.child("Headers").children()){
-            UtilFRequest::HttpHeader currentHeader;
+            UtilFRequest::HttpHeader currentRequestHeader;
 
-            currentHeader.name = QString(currentHeaderNode.child("Key").child_value());
-            currentHeader.value = currentHeaderNode.child("Value").child_value();
+            currentRequestHeader.name = QString(currentHeaderNode.child("Key").child_value());
+            currentRequestHeader.value = currentHeaderNode.child("Value").child_value();
 
-            requestHeaders.append(currentHeader);
+            requestHeaders.append(currentRequestHeader);
         }
 
         currentRequestInfo.headers = requestHeaders;
@@ -181,17 +181,17 @@ ProjectFileFRequest::ProjectData ProjectFileFRequest::readProjectDataFromFile(co
         currentProjectData.projectRequests.append(currentRequestInfo);
     }
 
-    pugi::xml_node headers = doc.select_node("/FRequestProject/GlobalHeaders").node();
+    pugi::xml_node globalHeadersNode = doc.select_node("/FRequestProject/GlobalHeaders").node();
 
     QVector<UtilFRequest::HttpHeader> globalHeaders;
 
-    for(const pugi::xml_node &currentHeaderNode : headers.children()){
-        UtilFRequest::HttpHeader currentHeader;
+    for(const pugi::xml_node &currentGlobalHeaderNode : globalHeadersNode.children()){
+        UtilFRequest::HttpHeader currentGlobalHeader;
 
-        currentHeader.name = QString(currentHeaderNode.child("Key").child_value());
-        currentHeader.value = currentHeaderNode.child("Value").child_value();
+        currentGlobalHeader.name = QString(currentGlobalHeaderNode.child("Key").child_value());
+        currentGlobalHeader.value = currentGlobalHeaderNode.child("Value").child_value();
 
-        globalHeaders.append(currentHeader);
+        globalHeaders.append(currentGlobalHeader);
     }
     currentProjectData.globalHeaders = globalHeaders;
 
@@ -344,25 +344,25 @@ void ProjectFileFRequest::saveProjectDataToFile(const QString &fileFullPath, con
         // remove headers if they exist, we will rebuild them
         requestNode.remove_child("Headers");
 
-        pugi::xml_node headersNode = requestNode.append_child("Headers");
+        pugi::xml_node requestHeadersNode = requestNode.append_child("Headers");
 
-        for(const UtilFRequest::HttpHeader &currentHeader : currentRequest.headers){
-            pugi::xml_node currentHeaderNode = headersNode.append_child("Header");
+        for(const UtilFRequest::HttpHeader &currentRequestHeader : currentRequest.headers){
+            pugi::xml_node currentRequestHeaderNode = requestHeadersNode.append_child("Header");
 
-            currentHeaderNode.append_child("Key").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentHeader.name));
-            currentHeaderNode.append_child("Value").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentHeader.value));
+            currentRequestHeaderNode.append_child("Key").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentRequestHeader.name));
+            currentRequestHeaderNode.append_child("Value").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentRequestHeader.value));
         }
 
     }
 
     rootNode.remove_child("GlobalHeaders");
 
-    pugi::xml_node headersNode = rootNode.append_child("GlobalHeaders");
-    for (const UtilFRequest::HttpHeader &currentHeader: newProjectData.globalHeaders) {
-        pugi::xml_node currentHeaderNode = headersNode.append_child("Header");
+    pugi::xml_node globalHeadersNode = rootNode.append_child("GlobalHeaders");
+    for (const UtilFRequest::HttpHeader &currentGlobalHeader: newProjectData.globalHeaders) {
+        pugi::xml_node currentGlobalHeaderNode = globalHeadersNode.append_child("Header");
 
-        currentHeaderNode.append_child("Key").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentHeader.name));
-        currentHeaderNode.append_child("Value").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentHeader.value));
+        currentGlobalHeaderNode.append_child("Key").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentGlobalHeader.name));
+        currentGlobalHeaderNode.append_child("Value").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentGlobalHeader.value));
     }
 
     const pugi::char_t* const identCharacterChar = newProjectData.saveIdentCharacter == UtilFRequest::IdentCharacter::SPACE ? pugiIdentChars::spaceChar : pugiIdentChars::tabChar;

--- a/XmlParsers/projectfilefrequest.cpp
+++ b/XmlParsers/projectfilefrequest.cpp
@@ -157,6 +157,7 @@ ProjectFileFRequest::ProjectData ProjectFileFRequest::readProjectDataFromFile(co
         }
         }
 
+
         QVector<UtilFRequest::HttpHeader> requestHeaders;
 
         for(const pugi::xml_node &currentHeaderNode : currNode.child("Headers").children()){
@@ -179,6 +180,20 @@ ProjectFileFRequest::ProjectData ProjectFileFRequest::readProjectDataFromFile(co
 
         currentProjectData.projectRequests.append(currentRequestInfo);
     }
+
+    pugi::xml_node headers = doc.select_node("/FRequestProject/Headers").node();
+
+    QVector<UtilFRequest::HttpHeader> globalHeaders;
+
+    for(const pugi::xml_node &currentHeaderNode : headers.children()){
+        UtilFRequest::HttpHeader currentHeader;
+
+        currentHeader.name = QString(currentHeaderNode.child("Key").child_value());
+        currentHeader.value = currentHeaderNode.child("Value").child_value();
+
+        globalHeaders.append(currentHeader);
+    }
+    currentProjectData.globalHeaders = globalHeaders;
 
     return currentProjectData;
 }
@@ -337,6 +352,16 @@ void ProjectFileFRequest::saveProjectDataToFile(const QString &fileFullPath, con
             currentHeaderNode.append_child("Value").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentHeader.value));
         }
 
+    }
+
+    rootNode.remove_child("Headers");
+
+    pugi::xml_node headersNode = rootNode.append_child("Headers");
+    for (const UtilFRequest::HttpHeader &currentHeader: newProjectData.globalHeaders) {
+        pugi::xml_node currentHeaderNode = headersNode.append_child("Header");
+
+        currentHeaderNode.append_child("Key").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentHeader.name));
+        currentHeaderNode.append_child("Value").append_child(pugi::xml_node_type::node_cdata).set_value(QSTR_TO_CSTR(currentHeader.value));
     }
 
     const pugi::char_t* const identCharacterChar = newProjectData.saveIdentCharacter == UtilFRequest::IdentCharacter::SPACE ? pugiIdentChars::spaceChar : pugiIdentChars::tabChar;

--- a/XmlParsers/projectfilefrequest.cpp
+++ b/XmlParsers/projectfilefrequest.cpp
@@ -157,7 +157,6 @@ ProjectFileFRequest::ProjectData ProjectFileFRequest::readProjectDataFromFile(co
         }
         }
 
-
         QVector<UtilFRequest::HttpHeader> requestHeaders;
 
         for(const pugi::xml_node &currentHeaderNode : currNode.child("Headers").children()){

--- a/XmlParsers/projectfilefrequest.h
+++ b/XmlParsers/projectfilefrequest.h
@@ -38,6 +38,7 @@ public:
         std::shared_ptr<FRequestAuthentication> authData = nullptr;
         bool retryLoginIfError401 = false;
         UtilFRequest::IdentCharacter saveIdentCharacter;
+        QVector<UtilFRequest::HttpHeader> globalHeaders;
     };
 
 public:

--- a/XmlParsers/projectfilefrequest.h
+++ b/XmlParsers/projectfilefrequest.h
@@ -53,6 +53,8 @@ private:
 namespace pugiIdentChars {
     static constexpr pugi::char_t spaceChar[] = PUGIXML_TEXT("    "); // we use 4 spaces as default
     static constexpr pugi::char_t tabChar[] = PUGIXML_TEXT("\t");
+
+    const pugi::char_t* getIdentCharaterForEnum(const UtilFRequest::IdentCharacter identEnum);
 }
 
 #endif // PROJECTFILEFREQUEST_H

--- a/about.cpp
+++ b/about.cpp
@@ -33,13 +33,18 @@ About::About(QWidget *parent) :
                          "Written by Fábio Bento <a href='https://github.com/fabiobento512'>(fabiobento512)</a><br /><br/>"
                          "Build Date " + __DATE__ + " " + __TIME__ + "<br /><br />"
                          "Thanks to:<br/><br/>"
+                         "<b>Main contributors:</b><br />"
+                         "Alejandro Valdés (alevalv) for global headers feature<br />"
+                         "<br />"
+                         "<b>Libraries contributors:</b><br />"
                          "Arseny Kapoulkine and the remaining contributors for pugixml library<br />"
                          "Andrzej Krzemienski and the remaining contributors for C++14 optional library<br />"
                          "Sergey Podobry and the remaining contributors for plog library<br />"
                          "Jane G. (isomoar) for the JSON syntax highlighter (from SchemaBasedJSONEditor)<br />"
                          "Dmitry Ivanov for the XML syntax highlighter (from SchemaBasedJSONEditor)<br />"
-						 "Jürgen Skrotzky (Jorgen-VikingGod) for the Dark Theme<br />"
-                         "<br/>"
+                         "<br />"
+                         "<b>UI contributors:</b><br />"
+                         "Jürgen Skrotzky (Jorgen-VikingGod) for the Dark Theme<br />"
                          "Murakumon for project folder icon (found in findicons.com)<br />"
                          "Woothemes for application icon (found in findicons.com)<br />"
                          "ana nirwana for send request icon (found in iconfinder.com)<br />"
@@ -48,6 +53,7 @@ About::About(QWidget *parent) :
                          "Aha-Soft Team for abort icon (found in findicons.com)<br />"
                          "FatCow Web Hosting for warning icon (found in iconfinder.com) <a href='http://creativecommons.org/licenses/by/3.0/us/'>(license)</a><br />"
 						 "Icons8 for delete icon (found in <a href='https://icons8.com/'>here</a>) <a href='https://creativecommons.org/licenses/by-nd/3.0/'>(license)</a>"
+                         "<br />"
                          + R"(<hr/>
                          This program is free software: you can redistribute it and/or modify
                          it under the terms of the GNU General Public License as published by

--- a/main.cpp
+++ b/main.cpp
@@ -20,8 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mainwindow.h"
 #include <QApplication>
 
-#include "utilfrequest.h"
-
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -257,6 +257,10 @@ void MainWindow::on_pbSendRequest_clicked()
             }
         }
 
+        for (UtilFRequest::HttpHeader const& header : this->currentProjectItem->headers) {
+            requestFinalHeaders.append(header);
+        }
+
         this->ignoreAnyChangesToProject.SetCondition();
         formatRequestBody(getRequestCurrentSerializationFormatType());
         this->ignoreAnyChangesToProject.UnsetCondition();
@@ -1274,6 +1278,7 @@ void MainWindow::loadProjectState(const QString &filePath)
         this->currentProjectItem->projectMainUrl = projectData->mainUrl;
         this->currentProjectItem->authData = projectData->authData;
         this->currentProjectItem->saveIdentCharacter = projectData->saveIdentCharacter;
+        this->currentProjectItem->headers = projectData->globalHeaders;
 
         // Order them by the correct order
         std::sort(
@@ -1347,6 +1352,7 @@ ProjectFileFRequest::ProjectData MainWindow::fetchCurrentProjectData(){
     currentProjectData.projectUuid = this->currentProjectItem->getUuid();
     currentProjectData.authData = this->currentProjectItem->authData;
     currentProjectData.saveIdentCharacter = this->currentProjectItem->saveIdentCharacter;
+    currentProjectData.globalHeaders = this->currentProjectItem->headers;
 
     // Save by the current tree order
     for(int i=0; i<this->currentProjectItem->childCount(); i++){

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -495,12 +495,12 @@ void MainWindow::replyFinished(QNetworkReply *reply){
 
                 LOG_ERROR << requestReturnMessage;
 
-                QString statusErrorMessage = requestType + " was not performed with success." +
+                QString statusErrorMessage = requestType + " wasn't successful." +
                         (overridenRequest ? " Since this was an url overriden request, the authentication was not applied." : "");
 
                 // We show status bar error twice because if the user takes too long to click ok in error popup the message may not be seen by him
                 Util::StatusBar::showError(ui->statusBar, statusErrorMessage); // this one is necessary to override any previous message
-                Util::Dialogs::showError("An error occurred while performing the " + requestType + ".\n" + requestReturnMessage);
+//                Util::Dialogs::showError("An error occurred while performing the " + requestType + ".\n" + requestReturnMessage);
                 Util::StatusBar::showError(ui->statusBar, statusErrorMessage);
             }
 
@@ -2280,10 +2280,7 @@ void MainWindow::saveProjectProperties(){
 
     }
 
-    if(!this->unsavedChangesExist){
-        Util::Dialogs::showInfo("Project properties saved with success!");
-    }
-    else{
+    if (this->unsavedChangesExist) {
         Util::Dialogs::showWarning("Project properties weren't saved. Please save the project manually from file menu.");
     }
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1522,7 +1522,8 @@ void MainWindow::reloadRequest(FRequestTreeWidgetRequestItem* const item){
 
     if (!ui->cbGlobalHeaders->isChecked()) {
         for (UtilFRequest::HttpHeader const& header : currentProjectItem->globalHeaders) {
-            Util::TableWidget::addDisabledRow(ui->twRequestHeadersKeyValue, QStringList() << header.name << header.value);
+            Util::TableWidget::addRow(ui->twRequestHeadersKeyValue, QStringList() << header.name << header.value);
+            UtilFRequest::disableTableWidgetRow(ui->twRequestHeadersKeyValue, ui->twRequestHeadersKeyValue->rowCount()-1);
         }
     }
 
@@ -1880,7 +1881,7 @@ void MainWindow::on_cbRequestOverrideMainUrl_toggled(bool checked)
     buildFullPath();
 }
 
-void MainWindow::on_cbGlobalHeaders_toggled(bool checked)
+void MainWindow::on_cbGlobalHeaders_toggled(bool /*checked*/)
 {
     setProjectHasChanged();
     buildFullPath();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -255,7 +255,7 @@ void MainWindow::on_pbSendRequest_clicked()
 
         // we add the global headers only if they doesn't exist in the request
         // this is specially useful if we want to overwrite some existing header
-        for (UtilFRequest::HttpHeader const& header : this->currentProjectItem->headers) {
+        for (UtilFRequest::HttpHeader const& header : this->currentProjectItem->globalHeaders) {
             if (!headerMap.contains(header.name)) {
                 headerMap.insert(header.name, header.value);
             }
@@ -1285,7 +1285,7 @@ void MainWindow::loadProjectState(const QString &filePath)
         this->currentProjectItem->projectMainUrl = projectData->mainUrl;
         this->currentProjectItem->authData = projectData->authData;
         this->currentProjectItem->saveIdentCharacter = projectData->saveIdentCharacter;
-        this->currentProjectItem->headers = projectData->globalHeaders;
+        this->currentProjectItem->globalHeaders = projectData->globalHeaders;
 
         // Order them by the correct order
         std::sort(
@@ -1359,7 +1359,7 @@ ProjectFileFRequest::ProjectData MainWindow::fetchCurrentProjectData(){
     currentProjectData.projectUuid = this->currentProjectItem->getUuid();
     currentProjectData.authData = this->currentProjectItem->authData;
     currentProjectData.saveIdentCharacter = this->currentProjectItem->saveIdentCharacter;
-    currentProjectData.globalHeaders = this->currentProjectItem->headers;
+    currentProjectData.globalHeaders = this->currentProjectItem->globalHeaders;
 
     // Save by the current tree order
     for(int i=0; i<this->currentProjectItem->childCount(); i++){

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -170,6 +170,8 @@ private slots:
 
     void on_cbDisableGlobalHeaders_toggled(bool checked);
 
+    void on_twRequestHeadersKeyValue_currentItemChanged(QTableWidgetItem *current, QTableWidgetItem *previous);
+
 signals:
     void signalAppIsLoaded();
 	void signalRequestFinishedAndProcessed();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -168,6 +168,8 @@ private slots:
 
     void on_actionCheck_for_updates_triggered();
 
+    void on_cbGlobalHeaders_toggled(bool checked);
+
 signals:
     void signalAppIsLoaded();
 	void signalRequestFinishedAndProcessed();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -168,7 +168,7 @@ private slots:
 
     void on_actionCheck_for_updates_triggered();
 
-    void on_cbGlobalHeaders_toggled(bool checked);
+    void on_cbDisableGlobalHeaders_toggled(bool checked);
 
 signals:
     void signalAppIsLoaded();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -33,14 +33,14 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_12">
            <item>
-              <widget class="QLineEdit" name="leRequestsFilter">
-               <property name="placeholderText">
-                <string>Requests Filter</string>
-               </property>
-               <property name="clearButtonEnabled">
-                <bool>true</bool>
-               </property>
-              </widget>
+            <widget class="QLineEdit" name="leRequestsFilter">
+             <property name="placeholderText">
+              <string>Requests Filter</string>
+             </property>
+             <property name="clearButtonEnabled">
+              <bool>true</bool>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="FRequestTreeWidget" name="treeWidget">
@@ -207,7 +207,7 @@
                <item>
                 <widget class="QTabWidget" name="twRequest">
                  <property name="currentIndex">
-                  <number>0</number>
+                  <number>1</number>
                  </property>
                  <widget class="QWidget" name="tab_4">
                   <attribute name="title">
@@ -264,6 +264,9 @@
                        <property name="alternatingRowColors">
                         <bool>true</bool>
                        </property>
+                       <attribute name="horizontalHeaderStretchLastSection">
+                        <bool>true</bool>
+                       </attribute>
                        <column>
                         <property name="text">
                          <string>Key</string>
@@ -381,6 +384,12 @@
                        <property name="alternatingRowColors">
                         <bool>true</bool>
                        </property>
+                       <property name="wordWrap">
+                        <bool>true</bool>
+                       </property>
+                       <attribute name="horizontalHeaderStretchLastSection">
+                        <bool>true</bool>
+                       </attribute>
                        <column>
                         <property name="text">
                          <string>Key</string>
@@ -426,6 +435,16 @@
                       </layout>
                      </item>
                     </layout>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="cbGlobalHeaders">
+                     <property name="text">
+                      <string>Disable global headers</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
                    </item>
                   </layout>
                  </widget>
@@ -683,7 +702,7 @@ or alternatively just download the response as file.</string>
      <x>0</x>
      <y>0</y>
      <width>803</width>
-     <height>20</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>803</width>
-    <height>883</height>
+    <height>861</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,14 +33,14 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_12">
            <item>
-            <widget class="QLineEdit" name="leRequestsFilter">
-             <property name="placeholderText">
-              <string>Requests Filter</string>
-             </property>
-             <property name="clearButtonEnabled">
-              <bool>true</bool>
-             </property>
-            </widget>
+              <widget class="QLineEdit" name="leRequestsFilter">
+               <property name="placeholderText">
+                <string>Requests Filter</string>
+               </property>
+               <property name="clearButtonEnabled">
+                <bool>true</bool>
+               </property>
+              </widget>
            </item>
            <item>
             <widget class="FRequestTreeWidget" name="treeWidget">
@@ -207,7 +207,7 @@
                <item>
                 <widget class="QTabWidget" name="twRequest">
                  <property name="currentIndex">
-                  <number>1</number>
+                  <number>0</number>
                  </property>
                  <widget class="QWidget" name="tab_4">
                   <attribute name="title">
@@ -381,9 +381,6 @@
                        <property name="alternatingRowColors">
                         <bool>true</bool>
                        </property>
-                       <attribute name="horizontalHeaderStretchLastSection">
-                        <bool>true</bool>
-                       </attribute>
                        <column>
                         <property name="text">
                          <string>Key</string>
@@ -686,7 +683,7 @@ or alternatively just download the response as file.</string>
      <x>0</x>
      <y>0</y>
      <width>803</width>
-     <height>25</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -437,7 +437,7 @@
                     </layout>
                    </item>
                    <item>
-                    <widget class="QCheckBox" name="cbGlobalHeaders">
+                    <widget class="QCheckBox" name="cbDisableGlobalHeaders">
                      <property name="text">
                       <string>Disable global headers</string>
                      </property>
@@ -702,7 +702,7 @@ or alternatively just download the response as file.</string>
      <x>0</x>
      <y>0</y>
      <width>803</width>
-     <height>24</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>803</width>
-    <height>861</height>
+    <height>883</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,14 +33,14 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_12">
            <item>
-              <widget class="QLineEdit" name="leRequestsFilter">
-               <property name="placeholderText">
-                <string>Requests Filter</string>
-               </property>
-               <property name="clearButtonEnabled">
-                <bool>true</bool>
-               </property>
-              </widget>
+            <widget class="QLineEdit" name="leRequestsFilter">
+             <property name="placeholderText">
+              <string>Requests Filter</string>
+             </property>
+             <property name="clearButtonEnabled">
+              <bool>true</bool>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="FRequestTreeWidget" name="treeWidget">
@@ -207,7 +207,7 @@
                <item>
                 <widget class="QTabWidget" name="twRequest">
                  <property name="currentIndex">
-                  <number>0</number>
+                  <number>1</number>
                  </property>
                  <widget class="QWidget" name="tab_4">
                   <attribute name="title">
@@ -381,6 +381,9 @@
                        <property name="alternatingRowColors">
                         <bool>true</bool>
                        </property>
+                       <attribute name="horizontalHeaderStretchLastSection">
+                        <bool>true</bool>
+                       </attribute>
                        <column>
                         <property name="text">
                          <string>Key</string>
@@ -683,7 +686,7 @@ or alternatively just download the response as file.</string>
      <x>0</x>
      <y>0</y>
      <width>803</width>
-     <height>20</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -207,7 +207,7 @@
                <item>
                 <widget class="QTabWidget" name="twRequest">
                  <property name="currentIndex">
-                  <number>1</number>
+                  <number>0</number>
                  </property>
                  <widget class="QWidget" name="tab_4">
                   <attribute name="title">
@@ -438,6 +438,9 @@
                    </item>
                    <item>
                     <widget class="QCheckBox" name="cbDisableGlobalHeaders">
+                     <property name="toolTip">
+                      <string>Click to disable global headers for THIS request. Useful if you want to override the global headers or simply do not want to send them.</string>
+                     </property>
                      <property name="text">
                       <string>Disable global headers</string>
                      </property>

--- a/preferences.cpp
+++ b/preferences.cpp
@@ -89,8 +89,8 @@ void Preferences::accept (){
 
     // https://stackoverflow.com/a/16487964/1499019
     this->currentSettings.requestTimeout = QTime(0, 0, 0).secsTo(ui->teRequestTimeout->time());
-	
-	this->currentSettings.maxRequestResponseDataSizeToDisplay = ui->sbMaxRequestResponseDataSizeToDisplay->value();
+
+    this->currentSettings.maxRequestResponseDataSizeToDisplay = ui->sbMaxRequestResponseDataSizeToDisplay->value();
 
     if(ui->cbOnStartup->currentText() == "Load last project"){
         this->currentSettings.onStartupSelectedOption = ConfigFileFRequest::OnStartupOption::LOAD_LAST_PROJECT;
@@ -156,7 +156,7 @@ void Preferences::accept (){
     this->currentSettings.theme = newTheme;
 
     this->currentSettings.hideProjectSavedDialog = ui->cbHideProjectSavedDialog->isChecked();
-	
+
     emit saveSettings();
 
     QDialog::accept();
@@ -246,7 +246,7 @@ void Preferences::on_tbRequestBodyKeyValueRemove_clicked()
 
 void Preferences::loadExistingSettings(){
     ui->teRequestTimeout->setTime(QTime(0,0).addSecs(this->currentSettings.requestTimeout));
-	ui->sbMaxRequestResponseDataSizeToDisplay->setValue(this->currentSettings.maxRequestResponseDataSizeToDisplay);
+    ui->sbMaxRequestResponseDataSizeToDisplay->setValue(this->currentSettings.maxRequestResponseDataSizeToDisplay);
     ui->cbUseDefaultHeaders->setChecked(this->currentSettings.defaultHeaders.useDefaultHeaders);
     ui->cbSaveWindowGeometryWhenExiting->setChecked(this->currentSettings.windowsGeometry.saveWindowsGeometryWhenExiting);
     ui->cbProxyUseProxy->setChecked(this->currentSettings.useProxy);
@@ -314,8 +314,8 @@ void Preferences::loadExistingSettings(){
     ui->leProxyPort->setText(QString::number(this->currentSettings.proxySettings.portNumber));
 
     loadCurrentDefaultHeaders();
-	
-	ui->cbTheme->setCurrentText(ConfigFileFRequest::getFRequestThemeString(this->currentSettings.theme));
+
+    ui->cbTheme->setCurrentText(ConfigFileFRequest::getFRequestThemeString(this->currentSettings.theme));
 }
 
 void Preferences::loadCurrentDefaultHeaders(){

--- a/preferences.cpp
+++ b/preferences.cpp
@@ -154,6 +154,8 @@ void Preferences::accept (){
     }
 
     this->currentSettings.theme = newTheme;
+
+    this->currentSettings.hideProjectSavedDialog = ui->cbHideProjectSavedDialog->isChecked();
 	
     emit saveSettings();
 
@@ -248,6 +250,7 @@ void Preferences::loadExistingSettings(){
     ui->cbUseDefaultHeaders->setChecked(this->currentSettings.defaultHeaders.useDefaultHeaders);
     ui->cbSaveWindowGeometryWhenExiting->setChecked(this->currentSettings.windowsGeometry.saveWindowsGeometryWhenExiting);
     ui->cbProxyUseProxy->setChecked(this->currentSettings.useProxy);
+    ui->cbHideProjectSavedDialog->setChecked(this->currentSettings.hideProjectSavedDialog);
 
     // TODO Check if there's a better alternative to do this switches / ifs (maybe using enums??)
     // (without do direct string comparisons), because as it is, it is easy to break if we change any of the strings

--- a/preferences.ui
+++ b/preferences.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -262,7 +262,7 @@ As alternative try to download the response as file (since this way it writes al
            </item>
           </widget>
          </item>
-		 <item row="2" column="0">
+         <item row="2" column="0">
           <widget class="QLabel" name="label_9">
            <property name="text">
             <string>Theme:</string>

--- a/preferences.ui
+++ b/preferences.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -262,7 +262,7 @@ As alternative try to download the response as file (since this way it writes al
            </item>
           </widget>
          </item>
-         <item row="2" column="0">
+		 <item row="2" column="0">
           <widget class="QLabel" name="label_9">
            <property name="text">
             <string>Theme:</string>

--- a/preferences.ui
+++ b/preferences.ui
@@ -262,7 +262,7 @@ As alternative try to download the response as file (since this way it writes al
            </item>
           </widget>
          </item>
-		 <item row="2" column="0">
+         <item row="2" column="0">
           <widget class="QLabel" name="label_9">
            <property name="text">
             <string>Theme:</string>
@@ -315,6 +315,13 @@ As alternative try to download the response as file (since this way it writes al
         <widget class="QCheckBox" name="cbSaveWindowGeometryWhenExiting">
          <property name="text">
           <string>Save window geometry when exiting</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbHideProjectSavedDialog">
+         <property name="text">
+          <string>Hide confirmation when saving a project</string>
          </property>
         </widget>
        </item>

--- a/preferences.ui
+++ b/preferences.ui
@@ -321,7 +321,7 @@ As alternative try to download the response as file (since this way it writes al
        <item>
         <widget class="QCheckBox" name="cbHideProjectSavedDialog">
          <property name="text">
-          <string>Hide confirmation when saving a project</string>
+          <string>Hide confirmation dialog when saving a project</string>
          </property>
         </widget>
        </item>

--- a/projectproperties.cpp
+++ b/projectproperties.cpp
@@ -72,8 +72,10 @@ void ProjectProperties::fillInterface(){
 
     ui->cbIdentCharacter->setCurrentText(UtilFRequest::getIdentCharacterString(this->projectItem->saveIdentCharacter));
 
-    for (int i = 0; i < this->projectItem->headers.size(); i++) {
-        Util::TableWidget::addRow(ui->headerKeyValue, QStringList() << this->projectItem->headers.at(i).name << this->projectItem->headers.at(i).value);
+    for (int i = 0; i < this->projectItem->globalHeaders.size(); i++) {
+        Util::TableWidget::addRow(
+            ui->headerKeyValue,
+            QStringList() << this->projectItem->globalHeaders.at(i).name << this->projectItem->globalHeaders.at(i).value);
     }
 }
 
@@ -172,10 +174,10 @@ void ProjectProperties::accept (){
     }
     }
 
-    this->projectItem->headers.clear();
+    this->projectItem->globalHeaders.clear();
     for (int i = 0; i < ui->headerKeyValue->rowCount(); i++) {
         UtilFRequest::HttpHeader h = {ui->headerKeyValue->item(i, 0)->text(), ui->headerKeyValue->item(i, 1)->text()};
-        this->projectItem->headers.append(h);
+        this->projectItem->globalHeaders.append(h);
     }
 
     QDialog::accept();

--- a/projectproperties.cpp
+++ b/projectproperties.cpp
@@ -37,6 +37,25 @@ ProjectProperties::ProjectProperties(QWidget *parent, FRequestTreeWidgetProjectI
         // Unix time as sha256
         this->currentPasswordSalt = QCryptographicHash::hash(QByteArray().setNum(QDateTime::currentDateTime().toSecsSinceEpoch()), QCryptographicHash::Sha256).toHex();
     }
+
+    if(ui->cbRequestType->currentText() == "Request Authentication"){
+        ui->saProjectPropertiesNote->setVisible(true);
+    }
+    else{
+        ui->saProjectPropertiesNote->setVisible(false);
+    }
+
+    ui->lbProjectPropertiesNote->setText(
+                "<b>Note:</b> Request authentication works by selecting one of your requests as the one for the authentication.<br/><br/>"
+                "If you have a website you can find the request that you need by checking in your browser the one that authenticates you "
+                "(normally you could find it in a \"network\" tab), "
+                "then just replicate that request in FRequest and select it for the authentication here.<br/><br/>"
+                "Currently FRequest can only use a single request for the authentication.<br/><br/>"
+                "You should add in your authentication request the FRequest placeholders for the username and password, they are respectively "
+                "{{FREQUEST_AUTH_USERNAME}} and {{FREQUEST_AUTH_PASSWORD}}.<br/><br/>"
+                "You can add these placeholders either in the body of the request or in the headers. "
+                "FRequest will replace them automatically when authenticating by the username and password that you input above."
+                );
 }
 
 void ProjectProperties::fillInterface(){

--- a/projectproperties.h
+++ b/projectproperties.h
@@ -48,13 +48,14 @@ private slots:
     void accept ();
 
     void on_cbUseAuthentication_toggled(bool checked);
-    void on_headerKeyValueAdd_clicked();
-    void on_headerKeyValueRemove_clicked();
+    void on_tbGlobalHeaderKeyValueAdd_clicked();
+    void on_tbGlobalHeaderKeyValueRemove_clicked();
 
 private:
     void fillInterface();
 	void fillAuthenticationData(FRequestAuthentication &auth);
 	QString getComboBoxNameForRequest(const FRequestTreeWidgetRequestItem* const currentRequest);
+    void setRequestAuthenticationNote();
 	
 private:
     Ui::ProjectProperties *ui;

--- a/projectproperties.h
+++ b/projectproperties.h
@@ -48,6 +48,8 @@ private slots:
     void accept ();
 
     void on_cbUseAuthentication_toggled(bool checked);
+    void on_headerKeyValueAdd_clicked();
+    void on_headerKeyValueRemove_clicked();
 
 private:
     void fillInterface();

--- a/projectproperties.ui
+++ b/projectproperties.ui
@@ -239,13 +239,19 @@
            <string>Global Headers</string>
           </property>
           <layout class="QFormLayout" name="formLayout_4">
-           <item row="0" column="0">
+           <item row="0" column="0" colspan="2">
             <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <property name="sizeConstraint">
+              <enum>QLayout::SetDefaultConstraint</enum>
+             </property>
              <item>
               <widget class="QTableWidget" name="headerKeyValue">
                <property name="alternatingRowColors">
                 <bool>true</bool>
                </property>
+               <attribute name="horizontalHeaderStretchLastSection">
+                <bool>true</bool>
+               </attribute>
                <column>
                 <property name="text">
                  <string>Key</string>

--- a/projectproperties.ui
+++ b/projectproperties.ui
@@ -128,6 +128,19 @@
             </layout>
            </widget>
           </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
          </layout>
         </widget>
        </item>
@@ -160,7 +173,7 @@
           <enum>QLayout::SetMaximumSize</enum>
          </property>
          <item>
-          <widget class="QTableWidget" name="headerKeyValue">
+          <widget class="QTableWidget" name="twGlobalHeaderKeyValue">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
@@ -188,7 +201,7 @@
          <item>
           <layout class="QVBoxLayout" name="verticalLayout_7">
            <item>
-            <widget class="QToolButton" name="headerKeyValueAdd">
+            <widget class="QToolButton" name="tbGlobalHeaderKeyValueAdd">
              <property name="toolTip">
               <string>Add new row</string>
              </property>
@@ -202,7 +215,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QToolButton" name="headerKeyValueRemove">
+            <widget class="QToolButton" name="tbGlobalHeaderKeyValueRemove">
              <property name="toolTip">
               <string>Remove selected rows</string>
              </property>
@@ -241,108 +254,112 @@
          <property name="title">
           <string>Authentication</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_9">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="QLabel" name="lbSaveProjectAuthTo">
-            <property name="text">
-             <string>Save Project Authentication to:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QRadioButton" name="rbSaveProjectAuthToConfigurationFile">
-              <property name="toolTip">
-               <string>Saves the authentication data to Frequest configuration file, even if you share the project file the authentication data is not shared</string>
-              </property>
+           <layout class="QFormLayout" name="formLayout_2">
+            <item row="0" column="0">
+             <widget class="QLabel" name="lbSaveProjectAuthTo">
               <property name="text">
-               <string>FRequest Configuration File</string>
+               <string>Save Project Authentication to:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <item>
+               <widget class="QRadioButton" name="rbSaveProjectAuthToConfigurationFile">
+                <property name="toolTip">
+                 <string>Saves the authentication data to Frequest configuration file, even if you share the project file the authentication data is not shared</string>
+                </property>
+                <property name="text">
+                 <string>FRequest Configuration File</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="rbSaveProjectAuthToProjectFile">
+                <property name="toolTip">
+                 <string>Saves the authentication data to the Frequest project file, so if you share your project file the authentication data is also shared</string>
+                </property>
+                <property name="text">
+                 <string>FRequest Project File</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lbAuthType">
+              <property name="text">
+               <string>Authentication Type:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="cbRequestType">
+              <item>
+               <property name="text">
+                <string>Request Authentication</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Basic Authentication</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="lbRequestForAuthentication">
+              <property name="text">
+               <string>Request for Authentication:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QComboBox" name="cbRequestForAuthentication"/>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="lbUsername">
+              <property name="text">
+               <string>Username:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="leUsername"/>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="lbPassword">
+              <property name="text">
+               <string>Password:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="lePassword">
+              <property name="text">
+               <string/>
+              </property>
+              <property name="echoMode">
+               <enum>QLineEdit::Password</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0" colspan="2">
+             <widget class="QCheckBox" name="cbRetryLoginIfError401">
+              <property name="text">
+               <string>Retry login if the HTTP error 401 (Unauthorized) is received on a request</string>
               </property>
               <property name="checked">
                <bool>true</bool>
               </property>
              </widget>
             </item>
-            <item>
-             <widget class="QRadioButton" name="rbSaveProjectAuthToProjectFile">
-              <property name="toolTip">
-               <string>Saves the authentication data to the Frequest project file, so if you share your project file the authentication data is also shared</string>
-              </property>
-              <property name="text">
-               <string>FRequest Project File</string>
-              </property>
-             </widget>
-            </item>
            </layout>
-          </item>
-          <item>
-           <widget class="QLabel" name="lbAuthType">
-            <property name="text">
-             <string>Authentication Type:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="cbRequestType">
-            <item>
-             <property name="text">
-              <string>Request Authentication</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Basic Authentication</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="lbRequestForAuthentication">
-            <property name="text">
-             <string>Request for Authentication:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="cbRequestForAuthentication"/>
-          </item>
-          <item>
-           <widget class="QLabel" name="lbUsername">
-            <property name="text">
-             <string>Username:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="leUsername"/>
-          </item>
-          <item>
-           <widget class="QLabel" name="lbPassword">
-            <property name="text">
-             <string>Password:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="lePassword">
-            <property name="text">
-             <string/>
-            </property>
-            <property name="echoMode">
-             <enum>QLineEdit::Password</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbRetryLoginIfError401">
-            <property name="text">
-             <string>Retry login if the HTTP error 401 (Unauthorized) is received on a request</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
           </item>
           <item>
            <widget class="QScrollArea" name="saProjectPropertiesNote">
@@ -355,7 +372,7 @@
                <x>0</x>
                <y>0</y>
                <width>623</width>
-               <height>179</height>
+               <height>175</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -375,6 +392,19 @@
              </layout>
             </widget>
            </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>

--- a/projectproperties.ui
+++ b/projectproperties.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>782</width>
+    <height>725</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,263 +15,290 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="gbProjectProperties">
-     <property name="title">
-      <string>Project Properties</string>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QGroupBox" name="gbGeneral">
-        <property name="title">
-         <string>General</string>
-        </property>
-        <layout class="QFormLayout" name="formLayout">
-         <item row="0" column="0">
-          <widget class="QLabel" name="lbProjectName">
-           <property name="text">
-            <string>Project Name:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="leProjectName"/>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="lbProjectMainUrl">
-           <property name="text">
-            <string>Project Main Url:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="leProjectMainUrl"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cbUseAuthentication">
-        <property name="text">
-         <string>Use Authentication</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="gbAuthentication">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="title">
-         <string>Authentication</string>
-        </property>
-        <layout class="QFormLayout" name="formLayout_2">
-         <item row="0" column="0">
-          <widget class="QLabel" name="lbSaveProjectAuthTo">
-           <property name="text">
-            <string>Save Project Authentication to:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="lbAuthType">
-           <property name="text">
-            <string>Authentication Type:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="lbUsername">
-           <property name="text">
-            <string>Username:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="lbPassword">
-           <property name="text">
-            <string>Password:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbRetryLoginIfError401">
-           <property name="text">
-            <string>Retry login if the HTTP error 401 (Unauthorized) is received on a request</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QComboBox" name="cbRequestType">
-           <item>
-            <property name="text">
-             <string>Request Authentication</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Basic Authentication</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="QLineEdit" name="leUsername"/>
-         </item>
-         <item row="7" column="1">
-          <widget class="QLineEdit" name="lePassword">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="echoMode">
-            <enum>QLineEdit::Password</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="lbRequestForAuthentication">
-           <property name="text">
-            <string>Request for Authentication:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QComboBox" name="cbRequestForAuthentication"/>
-         </item>
-         <item row="0" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout">
-           <item>
-            <widget class="QRadioButton" name="rbSaveProjectAuthToConfigurationFile">
-             <property name="toolTip">
-              <string>Saves the authentication data to Frequest configuration file, even if you share the project file the authentication data is not shared</string>
-             </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>762</width>
+        <height>673</height>
+       </rect>
+      </property>
+      <widget class="QGroupBox" name="gbProjectProperties">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>782</width>
+         <height>671</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>Project Properties</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QGroupBox" name="gbGeneral">
+          <property name="title">
+           <string>General</string>
+          </property>
+          <layout class="QFormLayout" name="formLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="lbProjectName">
              <property name="text">
-              <string>FRequest Configuration File</string>
+              <string>Project Name:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="leProjectName"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="lbProjectMainUrl">
+             <property name="text">
+              <string>Project Main Url:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="leProjectMainUrl"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbUseAuthentication">
+          <property name="text">
+           <string>Use Authentication</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gbAuthentication">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="title">
+           <string>Authentication</string>
+          </property>
+          <layout class="QFormLayout" name="formLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="lbSaveProjectAuthTo">
+             <property name="text">
+              <string>Save Project Authentication to:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lbAuthType">
+             <property name="text">
+              <string>Authentication Type:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="lbUsername">
+             <property name="text">
+              <string>Username:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="lbPassword">
+             <property name="text">
+              <string>Password:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0" colspan="2">
+            <widget class="QCheckBox" name="cbRetryLoginIfError401">
+             <property name="text">
+              <string>Retry login if the HTTP error 401 (Unauthorized) is received on a request</string>
              </property>
              <property name="checked">
               <bool>true</bool>
              </property>
             </widget>
            </item>
-           <item>
-            <widget class="QRadioButton" name="rbSaveProjectAuthToProjectFile">
-             <property name="toolTip">
-              <string>Saves the authentication data to the Frequest project file, so if you share your project file the authentication data is also shared</string>
-             </property>
+           <item row="2" column="1">
+            <widget class="QComboBox" name="cbRequestType">
+             <item>
+              <property name="text">
+               <string>Request Authentication</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Basic Authentication</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QLineEdit" name="leUsername"/>
+           </item>
+           <item row="7" column="1">
+            <widget class="QLineEdit" name="lePassword">
              <property name="text">
-              <string>FRequest Project File</string>
+              <string/>
+             </property>
+             <property name="echoMode">
+              <enum>QLineEdit::Password</enum>
              </property>
             </widget>
            </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="lbRequestForAuthentication">
+             <property name="text">
+              <string>Request for Authentication:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QComboBox" name="cbRequestForAuthentication"/>
+           </item>
+           <item row="0" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QRadioButton" name="rbSaveProjectAuthToConfigurationFile">
+               <property name="toolTip">
+                <string>Saves the authentication data to Frequest configuration file, even if you share the project file the authentication data is not shared</string>
+               </property>
+               <property name="text">
+                <string>FRequest Configuration File</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="rbSaveProjectAuthToProjectFile">
+               <property name="toolTip">
+                <string>Saves the authentication data to the Frequest project file, so if you share your project file the authentication data is also shared</string>
+               </property>
+               <property name="text">
+                <string>FRequest Project File</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
           </layout>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="groupBox">
-        <property name="title">
-         <string>On Save</string>
-        </property>
-        <layout class="QFormLayout" name="formLayout_3">
-         <item row="0" column="0">
-          <widget class="QLabel" name="lbIdentCharacter">
-           <property name="toolTip">
-            <string>Specifies the type of white space to use when identing the project xml file (on save).</string>
-           </property>
-           <property name="text">
-            <string>Ident character:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cbIdentCharacter">
-           <property name="toolTip">
-            <string>Specifies the type of white space to use when identing the project xml file (on save).</string>
-           </property>
-           <item>
-            <property name="text">
-             <string>Space</string>
-            </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox">
+          <property name="title">
+           <string>On Save</string>
+          </property>
+          <layout class="QFormLayout" name="formLayout_3">
+           <item row="0" column="0">
+            <widget class="QLabel" name="lbIdentCharacter">
+             <property name="toolTip">
+              <string>Specifies the type of white space to use when identing the project xml file (on save).</string>
+             </property>
+             <property name="text">
+              <string>Ident character:</string>
+             </property>
+            </widget>
            </item>
-           <item>
-            <property name="text">
-             <string>Tab</string>
-            </property>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="cbIdentCharacter">
+             <property name="toolTip">
+              <string>Specifies the type of white space to use when identing the project xml file (on save).</string>
+             </property>
+             <item>
+              <property name="text">
+               <string>Space</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Tab</string>
+              </property>
+             </item>
+            </widget>
            </item>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QScrollArea" name="saProjectPropertiesNote">
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents_2">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>780</width>
-        <height>68</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="QLabel" name="lbProjectPropertiesNote">
-         <property name="text">
-          <string>Note:</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gbHeaders">
+          <property name="title">
+           <string>Global Headers</string>
+          </property>
+          <layout class="QFormLayout" name="formLayout_4">
+           <item row="0" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <item>
+              <widget class="QTableWidget" name="headerKeyValue">
+               <property name="alternatingRowColors">
+                <bool>true</bool>
+               </property>
+               <column>
+                <property name="text">
+                 <string>Key</string>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>Value</string>
+                </property>
+               </column>
+              </widget>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_7">
+               <item>
+                <widget class="QToolButton" name="headerKeyValueAdd">
+                 <property name="toolTip">
+                  <string>Add new row</string>
+                 </property>
+                 <property name="text">
+                  <string>...</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="Resources/resources.qrc">
+                   <normaloff>:/icons/plus.png</normaloff>:/icons/plus.png</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QToolButton" name="headerKeyValueRemove">
+                 <property name="toolTip">
+                  <string>Remove selected rows</string>
+                 </property>
+                 <property name="text">
+                  <string>...</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="Resources/resources.qrc">
+                   <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::MinimumExpanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -285,7 +312,9 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="Resources/resources.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/projectproperties.ui
+++ b/projectproperties.ui
@@ -6,303 +6,380 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>782</width>
-    <height>725</height>
+    <width>689</width>
+    <height>675</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Project Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMaximumSize</enum>
+   </property>
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="widgetResizable">
-      <bool>true</bool>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>1</number>
      </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>762</width>
-        <height>673</height>
-       </rect>
-      </property>
-      <widget class="QGroupBox" name="gbProjectProperties">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>782</width>
-         <height>671</height>
-        </rect>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="title">
-        <string>Project Properties</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QGroupBox" name="gbGeneral">
-          <property name="title">
-           <string>General</string>
+     <widget class="QWidget" name="tabGeneral">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QGroupBox" name="gbProjectProperties">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="autoFillBackground">
+          <bool>true</bool>
+         </property>
+         <property name="title">
+          <string>Project Properties</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignJustify|Qt::AlignVCenter</set>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMaximumSize</enum>
           </property>
-          <layout class="QFormLayout" name="formLayout">
-           <item row="0" column="0">
-            <widget class="QLabel" name="lbProjectName">
-             <property name="text">
-              <string>Project Name:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="leProjectName"/>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="lbProjectMainUrl">
-             <property name="text">
-              <string>Project Main Url:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLineEdit" name="leProjectMainUrl"/>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="cbUseAuthentication">
-          <property name="text">
-           <string>Use Authentication</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gbAuthentication">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="title">
-           <string>Authentication</string>
-          </property>
-          <layout class="QFormLayout" name="formLayout_2">
-           <item row="0" column="0">
-            <widget class="QLabel" name="lbSaveProjectAuthTo">
-             <property name="text">
-              <string>Save Project Authentication to:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="lbAuthType">
-             <property name="text">
-              <string>Authentication Type:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="lbUsername">
-             <property name="text">
-              <string>Username:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0">
-            <widget class="QLabel" name="lbPassword">
-             <property name="text">
-              <string>Password:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="9" column="0" colspan="2">
-            <widget class="QCheckBox" name="cbRetryLoginIfError401">
-             <property name="text">
-              <string>Retry login if the HTTP error 401 (Unauthorized) is received on a request</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QComboBox" name="cbRequestType">
-             <item>
-              <property name="text">
-               <string>Request Authentication</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Basic Authentication</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QLineEdit" name="leUsername"/>
-           </item>
-           <item row="7" column="1">
-            <widget class="QLineEdit" name="lePassword">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="echoMode">
-              <enum>QLineEdit::Password</enum>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="lbRequestForAuthentication">
-             <property name="text">
-              <string>Request for Authentication:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QComboBox" name="cbRequestForAuthentication"/>
-           </item>
-           <item row="0" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <item>
-              <widget class="QRadioButton" name="rbSaveProjectAuthToConfigurationFile">
-               <property name="toolTip">
-                <string>Saves the authentication data to Frequest configuration file, even if you share the project file the authentication data is not shared</string>
-               </property>
+          <item>
+           <widget class="QGroupBox" name="gbGeneral">
+            <property name="title">
+             <string>General</string>
+            </property>
+            <layout class="QFormLayout" name="formLayout">
+             <item row="0" column="0">
+              <widget class="QLabel" name="lbProjectName">
                <property name="text">
-                <string>FRequest Configuration File</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
+                <string>Project Name:</string>
                </property>
               </widget>
              </item>
-             <item>
-              <widget class="QRadioButton" name="rbSaveProjectAuthToProjectFile">
+             <item row="0" column="1">
+              <widget class="QLineEdit" name="leProjectName"/>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="lbProjectMainUrl">
+               <property name="text">
+                <string>Project Main Url:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLineEdit" name="leProjectMainUrl"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBox">
+            <property name="title">
+             <string>On Save</string>
+            </property>
+            <layout class="QFormLayout" name="formLayout_3">
+             <item row="0" column="0">
+              <widget class="QLabel" name="lbIdentCharacter">
                <property name="toolTip">
-                <string>Saves the authentication data to the Frequest project file, so if you share your project file the authentication data is also shared</string>
+                <string>Specifies the type of white space to use when identing the project xml file (on save).</string>
                </property>
                <property name="text">
-                <string>FRequest Project File</string>
+                <string>Ident character:</string>
                </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="cbIdentCharacter">
+               <property name="toolTip">
+                <string>Specifies the type of white space to use when identing the project xml file (on save).</string>
+               </property>
+               <item>
+                <property name="text">
+                 <string>Space</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Tab</string>
+                </property>
+               </item>
               </widget>
              </item>
             </layout>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox">
-          <property name="title">
-           <string>On Save</string>
-          </property>
-          <layout class="QFormLayout" name="formLayout_3">
-           <item row="0" column="0">
-            <widget class="QLabel" name="lbIdentCharacter">
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabGlobalHeaders">
+      <attribute name="title">
+       <string>Global Headers</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QLabel" name="globalHeadersDescription">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Any header added here will be appended (but not visible) to all requests in this project. Their values can be overwritten if the Request also has the same header key.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMaximumSize</enum>
+         </property>
+         <item>
+          <widget class="QTableWidget" name="headerKeyValue">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="alternatingRowColors">
+            <bool>true</bool>
+           </property>
+           <attribute name="horizontalHeaderStretchLastSection">
+            <bool>true</bool>
+           </attribute>
+           <column>
+            <property name="text">
+             <string>Key</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Value</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <item>
+            <widget class="QToolButton" name="headerKeyValueAdd">
              <property name="toolTip">
-              <string>Specifies the type of white space to use when identing the project xml file (on save).</string>
+              <string>Add new row</string>
              </property>
              <property name="text">
-              <string>Ident character:</string>
+              <string>...</string>
+             </property>
+             <property name="icon">
+              <iconset resource="Resources/resources.qrc">
+               <normaloff>:/icons/plus.png</normaloff>:/icons/plus.png</iconset>
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QComboBox" name="cbIdentCharacter">
+           <item>
+            <widget class="QToolButton" name="headerKeyValueRemove">
              <property name="toolTip">
-              <string>Specifies the type of white space to use when identing the project xml file (on save).</string>
+              <string>Remove selected rows</string>
              </property>
-             <item>
-              <property name="text">
-               <string>Space</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Tab</string>
-              </property>
-             </item>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="icon">
+              <iconset resource="Resources/resources.qrc">
+               <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
+             </property>
             </widget>
            </item>
           </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gbHeaders">
-          <property name="title">
-           <string>Global Headers</string>
-          </property>
-          <layout class="QFormLayout" name="formLayout_4">
-           <item row="0" column="0" colspan="2">
-            <layout class="QHBoxLayout" name="horizontalLayout_8">
-             <property name="sizeConstraint">
-              <enum>QLayout::SetDefaultConstraint</enum>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabAuthentication">
+      <attribute name="title">
+       <string>Authentication</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QCheckBox" name="cbUseAuthentication">
+         <property name="text">
+          <string>Use Authentication</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbAuthentication">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="title">
+          <string>Authentication</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QRadioButton" name="rbSaveProjectAuthToConfigurationFile">
+              <property name="toolTip">
+               <string>Saves the authentication data to Frequest configuration file, even if you share the project file the authentication data is not shared</string>
+              </property>
+              <property name="text">
+               <string>FRequest Configuration File</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="rbSaveProjectAuthToProjectFile">
+              <property name="toolTip">
+               <string>Saves the authentication data to the Frequest project file, so if you share your project file the authentication data is also shared</string>
+              </property>
+              <property name="text">
+               <string>FRequest Project File</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="lbSaveProjectAuthTo">
+            <property name="text">
+             <string>Save Project Authentication to:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="cbRequestType">
+            <item>
+             <property name="text">
+              <string>Request Authentication</string>
              </property>
-             <item>
-              <widget class="QTableWidget" name="headerKeyValue">
-               <property name="alternatingRowColors">
-                <bool>true</bool>
-               </property>
-               <attribute name="horizontalHeaderStretchLastSection">
-                <bool>true</bool>
-               </attribute>
-               <column>
+            </item>
+            <item>
+             <property name="text">
+              <string>Basic Authentication</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="lbAuthType">
+            <property name="text">
+             <string>Authentication Type:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="cbRequestForAuthentication"/>
+          </item>
+          <item>
+           <widget class="QLabel" name="lbRequestForAuthentication">
+            <property name="text">
+             <string>Request for Authentication:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="leUsername"/>
+          </item>
+          <item>
+           <widget class="QLabel" name="lbUsername">
+            <property name="text">
+             <string>Username:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="lePassword">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="echoMode">
+             <enum>QLineEdit::Password</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="lbPassword">
+            <property name="text">
+             <string>Password:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbRetryLoginIfError401">
+            <property name="text">
+             <string>Retry login if the HTTP error 401 (Unauthorized) is received on a request</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QScrollArea" name="saProjectPropertiesNote">
+            <property name="widgetResizable">
+             <bool>true</bool>
+            </property>
+            <widget class="QWidget" name="scrollAreaWidgetContents_2">
+             <property name="geometry">
+              <rect>
+               <x>0</x>
+               <y>0</y>
+               <width>623</width>
+               <height>165</height>
+              </rect>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_8">
+              <item>
+               <widget class="QLabel" name="lbProjectPropertiesNote">
                 <property name="text">
-                 <string>Key</string>
+                 <string>Note:</string>
                 </property>
-               </column>
-               <column>
-                <property name="text">
-                 <string>Value</string>
+                <property name="wordWrap">
+                 <bool>true</bool>
                 </property>
-               </column>
-              </widget>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="verticalLayout_7">
-               <item>
-                <widget class="QToolButton" name="headerKeyValueAdd">
-                 <property name="toolTip">
-                  <string>Add new row</string>
-                 </property>
-                 <property name="text">
-                  <string>...</string>
-                 </property>
-                 <property name="icon">
-                  <iconset resource="Resources/resources.qrc">
-                   <normaloff>:/icons/plus.png</normaloff>:/icons/plus.png</iconset>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QToolButton" name="headerKeyValueRemove">
-                 <property name="toolTip">
-                  <string>Remove selected rows</string>
-                 </property>
-                 <property name="text">
-                  <string>...</string>
-                 </property>
-                 <property name="icon">
-                  <iconset resource="Resources/resources.qrc">
-                   <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>

--- a/projectproperties.ui
+++ b/projectproperties.ui
@@ -35,7 +35,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabGeneral">
       <attribute name="title">
@@ -147,7 +147,7 @@
           </size>
          </property>
          <property name="text">
-          <string>Any header added here will be appended (but not visible) to all requests in this project. Their values can be overwritten if the Request also has the same header key.</string>
+          <string>Any header added here will be appended to all requests in this project. They will be shown in the request table as disabled rows if the checkbox is disabled. Their values can be overwritten if a header with the same key is added.</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -243,6 +243,13 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_9">
           <item>
+           <widget class="QLabel" name="lbSaveProjectAuthTo">
+            <property name="text">
+             <string>Save Project Authentication to:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
              <widget class="QRadioButton" name="rbSaveProjectAuthToConfigurationFile">
@@ -270,9 +277,9 @@
            </layout>
           </item>
           <item>
-           <widget class="QLabel" name="lbSaveProjectAuthTo">
+           <widget class="QLabel" name="lbAuthType">
             <property name="text">
-             <string>Save Project Authentication to:</string>
+             <string>Authentication Type:</string>
             </property>
            </widget>
           </item>
@@ -291,16 +298,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="lbAuthType">
-            <property name="text">
-             <string>Authentication Type:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="cbRequestForAuthentication"/>
-          </item>
-          <item>
            <widget class="QLabel" name="lbRequestForAuthentication">
             <property name="text">
              <string>Request for Authentication:</string>
@@ -308,12 +305,22 @@
            </widget>
           </item>
           <item>
-           <widget class="QLineEdit" name="leUsername"/>
+           <widget class="QComboBox" name="cbRequestForAuthentication"/>
           </item>
           <item>
            <widget class="QLabel" name="lbUsername">
             <property name="text">
              <string>Username:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="leUsername"/>
+          </item>
+          <item>
+           <widget class="QLabel" name="lbPassword">
+            <property name="text">
+             <string>Password:</string>
             </property>
            </widget>
           </item>
@@ -324,13 +331,6 @@
             </property>
             <property name="echoMode">
              <enum>QLineEdit::Password</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="lbPassword">
-            <property name="text">
-             <string>Password:</string>
             </property>
            </widget>
           </item>
@@ -355,7 +355,7 @@
                <x>0</x>
                <y>0</y>
                <width>623</width>
-               <height>165</height>
+               <height>179</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_8">

--- a/utilfrequest.cpp
+++ b/utilfrequest.cpp
@@ -329,7 +329,7 @@ SerializationFormatType getSerializationFormatTypeForString(const QString &conte
 
 QByteArray simpleStringObfuscationDeobfuscation(const QString& ofuscationSalt, const QString &input){
 
-	QByteArray saltByteArray = ofuscationSalt.toUtf8();
+    QByteArray saltByteArray = ofuscationSalt.toUtf8();
     QByteArray inputByteArray = input.toUtf8();
 
     // Using unsigned types as they have a defined truncation in iso c++:
@@ -346,9 +346,19 @@ QByteArray simpleStringObfuscationDeobfuscation(const QString& ofuscationSalt, c
 }
 
 QString replaceFRequestAuthenticationPlaceholders(const QString &textToReplace, const QString &username, const QString &password){
-	return QString(textToReplace).
-	replace(GlobalVars::FRequestAuthenticationPlaceholderUsername, username).
-	replace(GlobalVars::FRequestAuthenticationPlaceholderPassword, password);
+    return QString(textToReplace).
+            replace(GlobalVars::FRequestAuthenticationPlaceholderUsername, username).
+            replace(GlobalVars::FRequestAuthenticationPlaceholderPassword, password);
+}
+
+void disableTableWidgetRow(QTableWidget *myTable, const int rowNumber){
+
+    for(int i=0; i<myTable->columnCount(); i++){
+        QTableWidgetItem * const currentItem = myTable->item(rowNumber, i);
+
+        currentItem->setFlags(currentItem->flags() & ~Qt::ItemIsEditable);
+    }
+
 }
 
 }

--- a/utilfrequest.cpp
+++ b/utilfrequest.cpp
@@ -351,14 +351,60 @@ QString replaceFRequestAuthenticationPlaceholders(const QString &textToReplace, 
             replace(GlobalVars::FRequestAuthenticationPlaceholderPassword, password);
 }
 
-void disableTableWidgetRow(QTableWidget *myTable, const int rowNumber){
+void setGlobalHeaderTableWidgetRow(QTableWidget *myTable, const int rowNumber){
 
     for(int i=0; i<myTable->columnCount(); i++){
         QTableWidgetItem * const currentItem = myTable->item(rowNumber, i);
 
         currentItem->setFlags(currentItem->flags() & ~Qt::ItemIsEditable);
+
+        currentItem->setBackground(getTableWidgetRowDisabledBackStyle());
+        currentItem->setForeground(getTableWidgetRowDisabledTextStyle());
+
     }
 
+}
+
+//Reset a item to its initial style
+void resetGlobalTableWidgetRow(QTableWidget *myTable, const int rowNumber){
+
+    for(int i=0; i<myTable->columnCount(); i++){
+
+        QTableWidgetItem * const currentItem = myTable->item(rowNumber, i);
+
+        currentItem->setFlags(currentItem->flags() & Qt::ItemIsEditable);
+
+        if((currentItem->row()+1)%2==0){ //if the row number is par it use the alternate color scheme
+            currentItem->setBackground(QPalette().brush(QPalette::Normal,QPalette::AlternateBase));
+        }
+        else{
+            currentItem->setBackground(QPalette().brush(QPalette::Normal,QPalette::Base));
+        }
+
+        currentItem->setForeground(QPalette().brush(QPalette::Normal,QPalette::WindowText));
+
+    }
+
+}
+
+bool isGlobalHeaderTableWidgetRow(QTableWidget *myTable, const int rowNumber){
+
+    if(myTable->columnCount() <= 0){
+        return true;
+    }
+
+    const QTableWidgetItem * const currItem = myTable->item(rowNumber, 0);
+
+    return currItem->background() == getTableWidgetRowDisabledBackStyle() &&
+            currItem->foreground() == getTableWidgetRowDisabledTextStyle();
+}
+
+QBrush getTableWidgetRowDisabledBackStyle(){
+    return QTableWidget().palette().brush(QPalette::Disabled,QPalette::Base);
+}
+
+QBrush getTableWidgetRowDisabledTextStyle(){
+    return QTableWidget().palette().brush(QPalette::Disabled,QPalette::WindowText);
 }
 
 }

--- a/utilfrequest.h
+++ b/utilfrequest.h
@@ -154,8 +154,13 @@ QByteArray simpleStringObfuscationDeobfuscation(const QString& ofuscationSalt, c
 // Replaces the textToReplace string with the actual username and password given (uses the FRequest Auth Placeholders for the replace)
 QString replaceFRequestAuthenticationPlaceholders(const QString &textToReplace, const QString &username, const QString &password);
 
-void disableTableWidgetRow(QTableWidget *myTable, const int rowNumber);
-
+void setGlobalHeaderTableWidgetRow(QTableWidget *myTable, const int rowNumber);
+void resetGlobalTableWidgetRow(QTableWidget *myTable, const int rowNumber);
+bool isGlobalHeaderTableWidgetRow(QTableWidget *myTable, const int rowNumber);
+// we can't use a static object for this because we will receive an error:
+// "QWidget: Must construct a QApplication before a QWidget"
+QBrush getTableWidgetRowDisabledBackStyle();
+QBrush getTableWidgetRowDisabledTextStyle();
 }
 
 #endif // UTILFREQUEST_H

--- a/utilfrequest.h
+++ b/utilfrequest.h
@@ -154,6 +154,8 @@ QByteArray simpleStringObfuscationDeobfuscation(const QString& ofuscationSalt, c
 // Replaces the textToReplace string with the actual username and password given (uses the FRequest Auth Placeholders for the replace)
 QString replaceFRequestAuthenticationPlaceholders(const QString &textToReplace, const QString &username, const QString &password);
 
+void disableTableWidgetRow(QTableWidget *myTable, const int rowNumber);
+
 }
 
 #endif // UTILFREQUEST_H

--- a/utilfrequest.h
+++ b/utilfrequest.h
@@ -119,6 +119,7 @@ struct RequestInfo{
 	bool bDownloadResponseAsFile = false;
 	QString uuid;
 	unsigned long long int order = 0;
+    bool bDisableGlobalHeaders = true;
 };
 
 static QMimeDatabase mimeDatabase;

--- a/utilglobalvars.h
+++ b/utilglobalvars.h
@@ -24,8 +24,8 @@ namespace GlobalVars{
 
 static const QString AppName = "FRequest";
 static const QString AppVersion = "1.2";
-static const QString LastCompatibleVersionConfig = "1.1b";
-static const QString LastCompatibleVersionProjects= "1.1c";
+static const QString LastCompatibleVersionConfig = "1.2";
+static const QString LastCompatibleVersionProjects= "1.2";
 static const QString AppConfigFileName = AppName + ".cfg";
 static const QString AppLogFileName = AppName.toLower() + ".log";
 static const QString FRequestAuthenticationPlaceholderUsername = "{{FREQUEST_AUTH_USERNAME}}";

--- a/utilglobalvars.h
+++ b/utilglobalvars.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace GlobalVars{
 
 static const QString AppName = "FRequest";
-static const QString AppVersion = "1.2";
+static const QString AppVersion = "1.2 (Development)";
 static const QString LastCompatibleVersionConfig = "1.2";
 static const QString LastCompatibleVersionProjects= "1.2";
 static const QString AppConfigFileName = AppName + ".cfg";

--- a/utilglobalvars.h
+++ b/utilglobalvars.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace GlobalVars{
 
 static const QString AppName = "FRequest";
-static const QString AppVersion = "1.1c";
+static const QString AppVersion = "1.2";
 static const QString LastCompatibleVersionConfig = "1.1b";
 static const QString LastCompatibleVersionProjects= "1.1c";
 static const QString AppConfigFileName = AppName + ".cfg";


### PR DESCRIPTION
This PR adds Global Headers and removes two dialogs, one when a request fails and one when the project is saved successfully.

Global Headers are defined at the project level and are shared by all existing Request under the project. They can be overwritten by the request if they have the same key.

This pull request also include a refactor of the projectproperties ui, adding tabs for better navigation.