### PR TITLE
Change desktop icon name

### DIFF
--- a/LinuxAppImageDeployment/frequest.desktop
+++ b/LinuxAppImageDeployment/frequest.desktop
@@ -6,4 +6,3 @@ Icon=frequest_icon
 Comment=A fast, lightweight and opensource desktop application to make HTTP(s) requests
 Categories=Development;
 Terminal=false
-Name[en_US]=frequest.desktop


### PR DESCRIPTION
Just a small change to the `.desktop` file that is embedded in the project.

Seems that for `en_US` the name displayed in the application browser is "frequest.desktop":

![image](https://github.com/fabiobento512/FRequest/assets/21236836/4074bac3-3180-44ca-9570-c0403235ddde)

Simply removing `Name[en_US]` should set it to a cleaner "FRequest".